### PR TITLE
Deploy admin site to Cloudflare Workers Sites

### DIFF
--- a/.github/workflows/words-alive.yml
+++ b/.github/workflows/words-alive.yml
@@ -40,6 +40,7 @@ jobs:
         run: make test
         env:
           DATABASE_URL: 'postgresql://postgres:postgres@localhost:5432/postgres'
+
   mobile:
     runs-on: ubuntu-latest
     steps:
@@ -54,6 +55,7 @@ jobs:
       - name: Lint
         working-directory: mobile
         run: npm run lint
+
   web:
     runs-on: ubuntu-latest
     steps:
@@ -68,7 +70,8 @@ jobs:
       - name: Lint
         working-directory: web
         run: npm run lint
-  deploy-staging:
+
+  deploy-backend-staging:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs:
@@ -112,7 +115,8 @@ jobs:
         run: heroku container:release web -a words-alive-staging
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-  deploy-prod:
+
+  deploy-backend-prod:
     if: contains(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     needs:
@@ -156,3 +160,53 @@ jobs:
         run: heroku container:release web -a words-alive
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+
+  deploy-web-staging:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs:
+      - backend
+      - mobile
+      - web
+    steps:
+      - name: Clone
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        working-directory: web
+        run: npm ci
+      - name: Build admin site
+        working-directory: web
+        run: npm run build:prod
+        env:
+          REACT_APP_BASE_URL: https://api-staging.wordsalive.org
+      - name: Publish
+        uses: cloudflare/wrangler-action@1.2.0
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          workingDirectory: web
+          environment: staging
+
+  deploy-web-prod:
+    if: contains(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs:
+      - backend
+      - mobile
+      - web
+    steps:
+      - name: Clone
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        working-directory: web
+        run: npm ci
+      - name: Build admin site
+        working-directory: web
+        run: npm run build:prod
+        env:
+          REACT_APP_BASE_URL: https://api.wordsalive.org
+      - name: Publish
+        uses: cloudflare/wrangler-action@1.2.0
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          workingDirectory: web
+          environment: prod

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# typescript
+/dist
+
 # dependencies
 /node_modules
 /.pnp
@@ -21,3 +24,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+

--- a/web/workers-site/.gitignore
+++ b/web/workers-site/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+worker

--- a/web/workers-site/index.js
+++ b/web/workers-site/index.js
@@ -1,0 +1,96 @@
+import { getAssetFromKV, mapRequestToAsset } from '@cloudflare/kv-asset-handler'
+
+/**
+ * The DEBUG flag will do two things that help during development:
+ * 1. we will skip caching on the edge, which makes it easier to
+ *    debug.
+ * 2. we will return an error message on exception in your Response rather
+ *    than the default 404.html page.
+ */
+const DEBUG = false
+
+addEventListener('fetch', event => {
+  try {
+    event.respondWith(handleEvent(event))
+  } catch (e) {
+    if (DEBUG) {
+      return event.respondWith(
+        new Response(e.message || e.toString(), {
+          status: 500,
+        }),
+      )
+    }
+    event.respondWith(new Response('Internal Error', { status: 500 }))
+  }
+})
+
+async function handleEvent(event) {
+  const url = new URL(event.request.url)
+  let options = {}
+
+  /**
+   * You can add custom logic to how we fetch your assets
+   * by configuring the function `mapRequestToAsset`
+   */
+  options.mapRequestToAsset = request => {
+    const url = new URL(request.url)
+    url.pathname = `/`
+    return mapRequestToAsset(new Request(url, request))
+  }
+
+  try {
+    if (DEBUG) {
+      // customize caching
+      options.cacheControl = {
+        bypassCache: true,
+      };
+    }
+    const page = await getAssetFromKV(event, options);
+
+    // allow headers to be altered
+    const response = new Response(page.body, page);
+
+    response.headers.set("X-XSS-Protection", "1; mode=block");
+    response.headers.set("X-Content-Type-Options", "nosniff");
+    response.headers.set("X-Frame-Options", "DENY");
+    response.headers.set("Referrer-Policy", "unsafe-url");
+    response.headers.set("Feature-Policy", "none");
+
+    return response;
+
+  } catch (e) {
+    // if an error is thrown try to serve the asset at 404.html
+    if (!DEBUG) {
+      try {
+        let notFoundResponse = await getAssetFromKV(event, {
+          mapRequestToAsset: req => new Request(`${new URL(req.url).origin}/404.html`, req),
+        })
+
+        return new Response(notFoundResponse.body, { ...notFoundResponse, status: 404 })
+      } catch (e) {}
+    }
+
+    return new Response(e.message || e.toString(), { status: 500 })
+  }
+}
+
+/**
+ * Here's one example of how to modify a request to
+ * remove a specific prefix, in this case `/docs` from
+ * the url. This can be useful if you are deploying to a
+ * route on a zone, or if you only want your static content
+ * to exist at a specific path.
+ */
+function handlePrefix(prefix) {
+  return request => {
+    // compute the default (e.g. / -> index.html)
+    let defaultAssetKey = mapRequestToAsset(request)
+    let url = new URL(defaultAssetKey.url)
+
+    // strip the prefix from the path for lookup
+    url.pathname = url.pathname.replace(prefix, '/')
+
+    // inherit all other props from the default request
+    return new Request(url.toString(), defaultAssetKey)
+  }
+}

--- a/web/workers-site/package-lock.json
+++ b/web/workers-site/package-lock.json
@@ -1,0 +1,74 @@
+{
+  "name": "worker",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "worker",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "~0.1.1"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.1.1.tgz",
+      "integrity": "sha512-loZzVTXfoSKsZ/VVeHGuRlQFcxUEmTPIyWx3Zti9/lShfhETZJ90nKpbvoWps7P60kILWpILE/5EfHDiumfYEQ==",
+      "dependencies": {
+        "@cloudflare/workers-types": "^2.0.0",
+        "@types/mime": "^2.0.2",
+        "mime": "^2.4.6"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-2.1.0.tgz",
+      "integrity": "sha512-VmXaHTq0lt6Xre4aK1hUK25hjZjuEUkHtdUEt0FJamv+NzQO54Gwp6Zr5Cfu6SP5EQ/tTmTMP/tK9npA8zhcCg=="
+    },
+    "node_modules/@types/mime": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
+      "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q=="
+    },
+    "node_modules/mime": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    }
+  },
+  "dependencies": {
+    "@cloudflare/kv-asset-handler": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.1.1.tgz",
+      "integrity": "sha512-loZzVTXfoSKsZ/VVeHGuRlQFcxUEmTPIyWx3Zti9/lShfhETZJ90nKpbvoWps7P60kILWpILE/5EfHDiumfYEQ==",
+      "requires": {
+        "@cloudflare/workers-types": "^2.0.0",
+        "@types/mime": "^2.0.2",
+        "mime": "^2.4.6"
+      }
+    },
+    "@cloudflare/workers-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-2.1.0.tgz",
+      "integrity": "sha512-VmXaHTq0lt6Xre4aK1hUK25hjZjuEUkHtdUEt0FJamv+NzQO54Gwp6Zr5Cfu6SP5EQ/tTmTMP/tK9npA8zhcCg=="
+    },
+    "@types/mime": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
+      "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q=="
+    },
+    "mime": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
+    }
+  }
+}

--- a/web/workers-site/package.json
+++ b/web/workers-site/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "name": "worker",
+  "version": "1.0.0",
+  "description": "A template for kick starting a Cloudflare Workers project",
+  "main": "index.js",
+  "author": "Ashley Lewis <ashleymichal@gmail.com>",
+  "license": "MIT",
+  "dependencies": {
+    "@cloudflare/kv-asset-handler": "~0.1.1"
+  }
+}

--- a/web/wrangler.toml
+++ b/web/wrangler.toml
@@ -1,0 +1,19 @@
+name = 'volunteers-dev'
+type = 'webpack'
+account_id = '457556e693275da88b8ad0aa6af04170'
+route = 'volunteers-dev.wordsalive.org/*'
+zone_id = '27f2804ddf864eafa1fa63b64be3951b'
+workers_dev = false
+target_type = "webpack"
+
+[site]
+bucket = "./build"
+entry-point = "workers-site"
+
+[env.staging]
+name = 'volunteers-staging'
+route = 'volunteers-staging.wordsalive.org/*'
+
+[env.prod]
+name = 'volunteers'
+route = 'volunteers.wordsalive.org/*'


### PR DESCRIPTION
### Administrative Info
Monday Board ID: 853642866

### Changes
Set up CI to auto-deploy the admin site to
volunteers-staging.wordsalive.org and volunteers.wordsalive.org on merge
to main and on tag, respectively.

The admin site is built using npm run build:prod, which creates a
production-ready bundle, which is then published to Cloudflare Workers
Sites. I considered GitHub pages too, but there's no easy way to have
separate staging and production environments in one repo. We're already
using CF for DNS/TLS and Workers has a pretty good free plan, so I went
with that.

Workers config lives in web/wrangler.toml and web/workers-site.
### Testing
The action was tested on my fork, see https://github.com/dacruz21/WA-Family-Literacy-Application/runs/2503306939?check_suite_focus=true for the logs.

### Confirmation of Change 

![image](https://user-images.githubusercontent.com/36964941/117054978-81c04000-accf-11eb-834a-009e7dc4d894.png)

