### PR TITLE
Realtime Chat API

### DIFF
--- a/backend/internal/auth/auth.go
+++ b/backend/internal/auth/auth.go
@@ -14,5 +14,5 @@ type Authenticator interface {
 	VerifyToken(ctx context.Context, token string) (string, bool)
 	CreateUser(ctx context.Context, email string, pwd string) (string, error)
 	DeleteUser(ctx context.Context, id string) error
- 	SetCustomUserClaims(ctx context.Context, id string, claims map[string]interface{}) error
+	SetCustomUserClaims(ctx context.Context, id string, claims map[string]interface{}) error
 }

--- a/backend/internal/auth/auth.go
+++ b/backend/internal/auth/auth.go
@@ -14,4 +14,5 @@ type Authenticator interface {
 	VerifyToken(ctx context.Context, token string) (string, bool)
 	CreateUser(ctx context.Context, email string, pwd string) (string, error)
 	DeleteUser(ctx context.Context, id string) error
+ 	SetCustomUserClaims(ctx context.Context, id string, claims map[string]interface{}) error
 }

--- a/backend/internal/auth/firebase.go
+++ b/backend/internal/auth/firebase.go
@@ -45,3 +45,7 @@ func (a FirebaseAuthenticator) CreateUser(ctx context.Context, email string, pwd
 func (a FirebaseAuthenticator) DeleteUser(ctx context.Context, id string) error {
 	return a.Client.DeleteUser(ctx, id)
 }
+
+func (a FirebaseAuthenticator) SetCustomUserClaims(ctx context.Context, id string, claims map[string]interface{}) error {
+	return a.Client.SetCustomUserClaims(ctx, id, claims)
+}	

--- a/backend/internal/auth/firebase.go
+++ b/backend/internal/auth/firebase.go
@@ -48,4 +48,4 @@ func (a FirebaseAuthenticator) DeleteUser(ctx context.Context, id string) error 
 
 func (a FirebaseAuthenticator) SetCustomUserClaims(ctx context.Context, id string, claims map[string]interface{}) error {
 	return a.Client.SetCustomUserClaims(ctx, id, claims)
-}	
+}

--- a/backend/internal/auth/mock.go
+++ b/backend/internal/auth/mock.go
@@ -26,3 +26,7 @@ func (a MockAuthenticator) CreateUser(ctx context.Context, email string, pwd str
 func (a MockAuthenticator) DeleteUser(ctx context.Context, id string) error {
 	return nil
 }
+
+func (a MockAuthenticator) SetCustomUserClaims(ctx context.Context, id string, claims map[string]interface{}) error {
+	return nil
+}

--- a/backend/internal/controllers/admin.go
+++ b/backend/internal/controllers/admin.go
@@ -63,6 +63,10 @@ func (c *AdminController) CreateAdmin(rw http.ResponseWriter, req *http.Request)
 		return
 	}
 
+	// Add admin custom claim to Firebase Authentication user
+	adminClaim := map[string]interface{}{"admin": true}
+	c.Auth.SetCustomUserClaims(req.Context(), cuid, adminClaim)
+
 	// Populate fields of admin account
 	admin.ID = cuid
 	admin.Name = cadmin.Name

--- a/backend/internal/controllers/admin.go
+++ b/backend/internal/controllers/admin.go
@@ -64,7 +64,7 @@ func (c *AdminController) CreateAdmin(rw http.ResponseWriter, req *http.Request)
 	}
 
 	// Add canChat custom claim to Firebase Authentication user
-	canChatClaim := map[string]interface{}{"canChat": cadmin.CanChat};
+	canChatClaim := map[string]interface{}{"canChat": cadmin.CanChat}
 	c.Auth.SetCustomUserClaims(req.Context(), cuid, canChatClaim)
 
 	// Populate fields of admin account
@@ -190,7 +190,7 @@ func (c *AdminController) UpdateAdmin(rw http.ResponseWriter, req *http.Request)
 	}
 
 	// Update canChat custom claim for Firebase Authentication user
-	canChatClaim := map[string]interface{}{"canChat": uadmin.CanChat};
+	canChatClaim := map[string]interface{}{"canChat": uadmin.CanChat}
 	c.Auth.SetCustomUserClaims(req.Context(), adminID, canChatClaim)
 
 	// Carry out update

--- a/backend/internal/controllers/admin.go
+++ b/backend/internal/controllers/admin.go
@@ -63,9 +63,9 @@ func (c *AdminController) CreateAdmin(rw http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	// Add admin custom claim to Firebase Authentication user
-	adminClaim := map[string]interface{}{"admin": true}
-	c.Auth.SetCustomUserClaims(req.Context(), cuid, adminClaim)
+	// Add canChat custom claim to Firebase Authentication user
+	canChatClaim := map[string]interface{}{"canChat": cadmin.CanChat};
+	c.Auth.SetCustomUserClaims(req.Context(), cuid, canChatClaim)
 
 	// Populate fields of admin account
 	admin.ID = cuid
@@ -76,6 +76,7 @@ func (c *AdminController) CreateAdmin(rw http.ResponseWriter, req *http.Request)
 	admin.CanEditBooks = cadmin.CanEditBooks
 	admin.CanDeleteBooks = cadmin.CanDeleteBooks
 	admin.CanAccessAnalytics = cadmin.CanAccessAnalytics
+	admin.CanChat = cadmin.CanChat
 
 	// Create new admin in database
 	err = c.Admins.CreateAdmin(req.Context(), admin)
@@ -187,6 +188,10 @@ func (c *AdminController) UpdateAdmin(rw http.ResponseWriter, req *http.Request)
 		writeResponse(rw, http.StatusBadRequest, "must be able to upload to edit/delete books")
 		return
 	}
+
+	// Update canChat custom claim for Firebase Authentication user
+	canChatClaim := map[string]interface{}{"canChat": uadmin.CanChat};
+	c.Auth.SetCustomUserClaims(req.Context(), adminID, canChatClaim)
 
 	// Carry out update
 	err = c.Admins.UpdateAdmin(req.Context(), adminID, uadmin)

--- a/backend/internal/controllers/admin_test.go
+++ b/backend/internal/controllers/admin_test.go
@@ -42,19 +42,22 @@ func TestPostAdmin(t *testing.T) {
 
 	body := `{"email": "admin1@test.com", "password": "p@ssw0rd!", "name": "adam", 
     "can_manage_users": true, "can_upload_books": true, "can_edit_books": true,
-    "can_delete_books" : false}`
+    "can_delete_books" : false, "can_chat": false}`
 	testutils.MakeAuthenticatedRequest(t, "POST", ts.URL+"/admins", body,
 		http.StatusOK, &response, "test-token-primary")
 
 	require.Equal(t, "admin1", response.ID)
+	require.Equal(t, false, response.CanChat)
 
 	body = `{"email": "intern1@test.com", "password": "p@ssw0rd!", "name": "ian", 
-    "can_manage_users": false, "can_upload_books": false, "can_delete_books" : false}`
+    "can_manage_users": false, "can_upload_books": false,
+	"can_chat": true, "can_delete_books" : false}`
 
 	testutils.MakeAuthenticatedRequest(t, "POST", ts.URL+"/admins", body,
 		http.StatusOK, &response, "test-token-primary")
 
 	require.Equal(t, "intern1", response.ID)
+	require.Equal(t, true, response.CanChat)
 }
 
 func TestPostAdminDuplicateEmail(t *testing.T) {
@@ -151,7 +154,7 @@ func TestUpdateAdmin(t *testing.T) {
 
 	require.Equal(t, true, response.CanEditBooks)
 
-	body := `{"can_edit_books": false}`
+	body := `{"can_edit_books": false, "can_chat": true}`
 	testutils.MakeAuthenticatedRequest(t, "PATCH", ts.URL+"/admins/admin1", body,
 		http.StatusOK, nil, "test-token-admin1")
 
@@ -159,6 +162,7 @@ func TestUpdateAdmin(t *testing.T) {
 		http.StatusOK, &response, "test-token-admin1")
 
 	require.Equal(t, false, response.CanEditBooks)
+	require.Equal(t, true, response.CanChat)
 }
 
 // Test delete request unauthorized

--- a/backend/internal/controllers/main_test.go
+++ b/backend/internal/controllers/main_test.go
@@ -75,8 +75,8 @@ func TestMain(m *testing.M) {
 	// Seed admin database with primary admin
 	conn.Exec(ctx, "INSERT INTO admins (id, email, name, can_manage_users, "+
 		"can_upload_books, can_edit_books, can_delete_books, can_access_analytics, "+
-		"is_primary_admin) VALUES "+
-		"('primary', 'admin@words.alive', 'admin', true, true, true, true, true, true)")
+		"can_chat, is_primary_admin) VALUES "+
+		"('primary', 'admin@words.alive', 'admin', true, true, true, true, true, true, true)")
 
 	conn.Exec(ctx, "INSERT INTO book_analytics (id, clicks) values "+
 		"('a_id', ARRAY_FILL(20, array[366]));")

--- a/backend/internal/controllers/middleware/requirePermission.go
+++ b/backend/internal/controllers/middleware/requirePermission.go
@@ -14,7 +14,7 @@ func RequirePermission(adminDB database.AdminDatabase, p models.Permission) func
 	// Check if permission enum is valid
 	switch p {
 	case models.CanManageUsers, models.CanUploadBooks, models.CanEditBooks,
-		models.CanDeleteBooks, models.CanAccessAnalytics:
+		models.CanDeleteBooks, models.CanAccessAnalytics, models.CanChat:
 	default:
 		panic("Invalid permission enum")
 	}
@@ -51,6 +51,8 @@ func RequirePermission(adminDB database.AdminDatabase, p models.Permission) func
 				permitted = perms.CanDeleteBooks
 			case models.CanAccessAnalytics:
 				permitted = perms.CanAccessAnalytics
+			case models.CanChat:
+				permitted = perms.CanChat
 			}
 
 			// Check selected permission

--- a/backend/internal/models/admin.go
+++ b/backend/internal/models/admin.go
@@ -10,7 +10,7 @@ type Admin struct {
 	CanEditBooks       bool   `json:"can_edit_books"`
 	CanDeleteBooks     bool   `json:"can_delete_books"`
 	CanAccessAnalytics bool   `json:"can_access_analytics"`
-	CanChat 		   bool   `json:"can_chat"`
+	CanChat            bool   `json:"can_chat"`
 	IsPrimaryAdmin     bool   `json:"is_primary_admin"`
 }
 
@@ -24,7 +24,7 @@ type CreateAdmin struct {
 	CanEditBooks       bool   `json:"can_edit_books"`
 	CanDeleteBooks     bool   `json:"can_delete_books"`
 	CanAccessAnalytics bool   `json:"can_access_analytics"`
-	CanChat 		   bool   `json:"can_chat"`
+	CanChat            bool   `json:"can_chat"`
 }
 
 // Struct to read in fields used when updating an admin
@@ -35,7 +35,7 @@ type UpdateAdmin struct {
 	CanEditBooks       *bool   `json:"can_edit_books"`
 	CanDeleteBooks     *bool   `json:"can_delete_books"`
 	CanAccessAnalytics *bool   `json:"can_access_analytics"`
-	CanChat 		   *bool   `json:"can_chat"`
+	CanChat            *bool   `json:"can_chat"`
 }
 
 // Struct used to track admin permissions
@@ -45,7 +45,7 @@ type Permissions struct {
 	CanEditBooks       bool
 	CanDeleteBooks     bool
 	CanAccessAnalytics bool
-	CanChat bool
+	CanChat            bool
 }
 
 type Permission int

--- a/backend/internal/models/admin.go
+++ b/backend/internal/models/admin.go
@@ -10,6 +10,7 @@ type Admin struct {
 	CanEditBooks       bool   `json:"can_edit_books"`
 	CanDeleteBooks     bool   `json:"can_delete_books"`
 	CanAccessAnalytics bool   `json:"can_access_analytics"`
+	CanChat 		   bool   `json:"can_chat"`
 	IsPrimaryAdmin     bool   `json:"is_primary_admin"`
 }
 
@@ -23,6 +24,7 @@ type CreateAdmin struct {
 	CanEditBooks       bool   `json:"can_edit_books"`
 	CanDeleteBooks     bool   `json:"can_delete_books"`
 	CanAccessAnalytics bool   `json:"can_access_analytics"`
+	CanChat 		   bool   `json:"can_chat"`
 }
 
 // Struct to read in fields used when updating an admin
@@ -33,6 +35,7 @@ type UpdateAdmin struct {
 	CanEditBooks       *bool   `json:"can_edit_books"`
 	CanDeleteBooks     *bool   `json:"can_delete_books"`
 	CanAccessAnalytics *bool   `json:"can_access_analytics"`
+	CanChat 		   *bool   `json:"can_chat"`
 }
 
 // Struct used to track admin permissions
@@ -42,6 +45,7 @@ type Permissions struct {
 	CanEditBooks       bool
 	CanDeleteBooks     bool
 	CanAccessAnalytics bool
+	CanChat bool
 }
 
 type Permission int
@@ -52,4 +56,5 @@ const (
 	CanEditBooks
 	CanDeleteBooks
 	CanAccessAnalytics
+	CanChat
 )

--- a/backend/migrations/20211111162644_add_can_chat_to_admin.sql
+++ b/backend/migrations/20211111162644_add_can_chat_to_admin.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE admins ADD COLUMN can_chat BOOL NOT NULL DEFAULT FALSE;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE admins DROP COLUMN can_chat;
+-- +goose StatementEnd

--- a/mobile/src/api/ChatAPI.ts
+++ b/mobile/src/api/ChatAPI.ts
@@ -1,0 +1,62 @@
+import firebase from 'firebase/app';
+import 'firebase/firestore';
+import { ChatRoom, Message } from '../models/Chat';
+
+// Class to encapsulate Chat functionality
+class ChatAPI {
+  chatRoomsCollection: firebase.firestore.DocumentData;
+
+  constructor() {
+    const fbConfig = process.env.REACT_APP_FB_CONFIG ? JSON.parse(process.env.REACT_APP_FB_CONFIG) : {
+      apiKey: process.env.REACT_APP_FB_API_KEY || 'AIzaSyBSJHJ-VfdN2Y3wC_vfD1k6bEU2mQmP-Vg',
+      authDomain: process.env.REACT_APP_FB_AUTH_DOMAIN || 'words-alive-staging.firebaseapp.com',
+      projectId: process.env.REACT_APP_FB_PROJECT_ID || 'words-alive-staging',
+      appId: process.env.REACT_APP_FB_APP_ID || '1:1534285739:web:2bada99614d9126d7224ee',
+    };
+    const app = firebase.apps[0] || firebase.initializeApp(fbConfig);
+    const db = app.firestore();
+    this.chatRoomsCollection = db.collection('chatRooms');
+  }
+
+  listenForRoomDetails(roomId: string, callback: (room: ChatRoom) => void): void{
+    const unsubscribe = this.chatRoomsCollection.doc(roomId).onSnapshot(doc => callback({id: doc.id, ...doc.data()}));
+    return unsubscribe;
+  }
+
+  // Listen for new messages in a chat room (calling this will initially return the current messages)
+  listenForNewMessages(roomId: string, callback: (messages: Message[]) => void): () => void {
+    const room = this.chatRoomsCollection.doc(roomId);
+    const unsubscribe = room
+      .collection('messages')
+      .orderBy('sentAt')
+      .onSnapshot((querySnapshot: firebase.firestore.QuerySnapshot) => {
+        const messages: Message[] = [];
+        querySnapshot.forEach((doc: firebase.firestore.DocumentData) => {
+          messages.push({ id: doc.id, ...doc.data() });
+        });
+        callback(messages);
+      });
+    return unsubscribe;
+  }
+
+  async createRoom(user: string): Promise<string> { 
+    const room = await this.chatRoomsCollection.add({
+      user,
+      resolved: false,
+      createdAt: new Date().toUTCString(),
+    });
+    return room.id;
+  }
+
+  //
+  sendMessage(roomId: string, text: string, from: string): void {
+    const room = this.chatRoomsCollection.doc(roomId);
+    room.collection('messages').add({
+      text,
+      from,
+      sentAt: new Date().toUTCString(),
+    });
+  }
+}
+
+export { ChatAPI };

--- a/mobile/src/api/ChatAPI.ts
+++ b/mobile/src/api/ChatAPI.ts
@@ -15,7 +15,7 @@ class ChatAPI {
   }
 
   listenForRoomDetails(roomId: string, callback: (room: ChatRoom) => void): void{
-    const unsubscribe = this.chatRoomsCollection.doc(roomId).onSnapshot(doc => callback({id: doc.id, ...doc.data()}));
+    const unsubscribe = this.chatRoomsCollection.doc(roomId).onSnapshot((doc: firebase.firestore.DocumentSnapshot) => callback({id: doc.id, ...doc.data()} as ChatRoom));
     return unsubscribe;
   }
 
@@ -28,7 +28,7 @@ class ChatAPI {
       .onSnapshot((querySnapshot: firebase.firestore.QuerySnapshot) => {
         const messages: Message[] = [];
         querySnapshot.docChanges().forEach(({ doc }: firebase.firestore.DocumentChange) => {
-          messages.push({ ...doc.data() as Message, id: doc.id });
+          messages.push({ ...doc.data(), id: doc.id } as Message);
         });
         callback(messages);
       });

--- a/mobile/src/api/ChatAPI.ts
+++ b/mobile/src/api/ChatAPI.ts
@@ -1,3 +1,4 @@
+import Constants from 'expo-constants';
 import firebase from 'firebase/app';
 import 'firebase/firestore';
 import { ChatRoom, Message } from '../models/Chat';
@@ -7,13 +8,7 @@ class ChatAPI {
   chatRoomsCollection: firebase.firestore.DocumentData;
 
   constructor() {
-    const fbConfig = process.env.REACT_APP_FB_CONFIG ? JSON.parse(process.env.REACT_APP_FB_CONFIG) : {
-      apiKey: process.env.REACT_APP_FB_API_KEY || 'AIzaSyBSJHJ-VfdN2Y3wC_vfD1k6bEU2mQmP-Vg',
-      authDomain: process.env.REACT_APP_FB_AUTH_DOMAIN || 'words-alive-staging.firebaseapp.com',
-      projectId: process.env.REACT_APP_FB_PROJECT_ID || 'words-alive-staging',
-      appId: process.env.REACT_APP_FB_APP_ID || '1:1534285739:web:2bada99614d9126d7224ee',
-    };
-    const app = firebase.apps[0] || firebase.initializeApp(fbConfig);
+    const app = firebase.apps[0] || firebase.initializeApp(Constants.manifest?.extra?.firebase);
     const db = app.firestore();
     this.chatRoomsCollection = db.collection('chatRooms');
   }
@@ -24,15 +19,15 @@ class ChatAPI {
   }
 
   // Listen for new messages in a chat room (calling this will initially return the current messages)
-  listenForNewMessages(roomId: string, callback: (messages: Message[]) => void): () => void {
+  listenForNewMessages(roomId: string, callback: (changedMessages: Message[]) => void): () => void {
     const room = this.chatRoomsCollection.doc(roomId);
     const unsubscribe = room
       .collection('messages')
       .orderBy('sentAt')
       .onSnapshot((querySnapshot: firebase.firestore.QuerySnapshot) => {
         const messages: Message[] = [];
-        querySnapshot.forEach((doc: firebase.firestore.DocumentData) => {
-          messages.push({ id: doc.id, ...doc.data() });
+        querySnapshot.docChanges().forEach(({ doc }: firebase.firestore.DocumentChange) => {
+          messages.push({ ...doc.data() as Message, id: doc.id });
         });
         callback(messages);
       });

--- a/mobile/src/api/ChatAPI.ts
+++ b/mobile/src/api/ChatAPI.ts
@@ -34,7 +34,7 @@ class ChatAPI {
     return unsubscribe;
   }
 
-  async createRoom(user: string): Promise<string> { 
+  async createRoom(user: string): Promise<string> {
     const room = await this.chatRoomsCollection.add({
       user,
       resolved: false,
@@ -43,13 +43,19 @@ class ChatAPI {
     return room.id;
   }
 
-  //
   sendMessage(roomId: string, text: string, from: string): void {
     const room = this.chatRoomsCollection.doc(roomId);
     room.collection('messages').add({
       text,
       from,
       sentAt: new Date().toUTCString(),
+    });
+  }
+
+  rateChat(roomId: string, rating: number): void {
+    const room = this.chatRoomsCollection.doc(roomId);
+    room.update({
+      rating
     });
   }
 }

--- a/mobile/src/api/ChatAPI.ts
+++ b/mobile/src/api/ChatAPI.ts
@@ -2,6 +2,7 @@ import Constants from 'expo-constants';
 import firebase from 'firebase/app';
 import 'firebase/firestore';
 import { ChatRoom, Message } from '../models/Chat';
+import { User } from '../models/User';
 
 // Class to encapsulate Chat functionality
 class ChatAPI {
@@ -34,9 +35,10 @@ class ChatAPI {
     return unsubscribe;
   }
 
-  async createRoom(user: string): Promise<string> {
+  async createRoom(user: User): Promise<string> {
     const room = await this.chatRoomsCollection.add({
-      user,
+      user: user.name,
+      userId: user.id,
       resolved: false,
       createdAt: new Date().toUTCString(),
     });

--- a/mobile/src/models/Chat.ts
+++ b/mobile/src/models/Chat.ts
@@ -1,0 +1,15 @@
+export type ChatRoom = {
+  id: string;
+  resolved: boolean;
+  messages: Message[];
+  user: string;
+  rating: number;
+  createdAt: Date;
+};
+
+export type Message = {
+  id: string;
+  text: string;
+  from: string;
+  sentAt: Date;
+};

--- a/mobile/src/screens/ChatScreen.tsx
+++ b/mobile/src/screens/ChatScreen.tsx
@@ -1,52 +1,148 @@
-import React, { useContext } from 'react';
-import { Linking, Text, View, StyleSheet, Image } from 'react-native';
+import React, { useContext, useEffect, useState } from 'react';
+import {
+  Linking,
+  Text,
+  View,
+  StyleSheet,
+  Image,
+  TextInput,
+  TouchableOpacity,
+} from 'react-native';
 import { I18nContext } from '../context/I18nContext';
 import { TextStyles } from '../styles/TextStyles';
 import { Colors } from '../styles/Colors';
+import { ChatAPI } from '../api/ChatAPI';
+import { ChatRoom, Message } from '../models/Chat';
+import { AuthContext } from '../context/AuthContext';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const chatAPI = new ChatAPI();
 
 /**
  * Left tab on navbar for chatting with volunteers
  */
 export const ChatScreen: React.FC = () => {
+  const auth = useContext(AuthContext);
+  const [roomId, setRoomId] = useState<string | undefined>();
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [messageText, setMessageText] = useState<string>('');
   const i18nCtx = useContext(I18nContext);
+
+  const onMessagesChange = (messages: Message[]): void => {
+    setMessages(messages);
+  };
+
+  const onRoomDataChange = ({ id, resolved, rating }: ChatRoom): void => {
+    if (resolved && rating) {
+      AsyncStorage.removeItem('chatRoomId');
+      setMessages([]);
+      setRoomId(undefined);
+    } else {
+      chatAPI.listenForNewMessages(id, onMessagesChange);
+    }
+  };
+
+  // Use roomId from previous session if exist
+  useEffect(() => {
+    AsyncStorage.getItem('chatRoomId').then((id) => setRoomId(id));
+  }, []);
+
+  // Keep using room unless it has been resolved and rated
+  useEffect(() => {
+    if (roomId) {
+      console.log(roomId);
+      return chatAPI.listenForRoomDetails(roomId, onRoomDataChange);
+    }
+  }, [roomId]);
+
+  const sendMessage = async (): Promise<void> => {
+    let newRoomId: string;
+    if (!roomId) {
+      newRoomId = await chatAPI.createRoom(auth.user?.name || 'Guest User');
+      setRoomId(newRoomId);
+    }
+    console.log(roomId, newRoomId);
+    chatAPI.sendMessage(
+      roomId || newRoomId,
+      messageText,
+      auth.user?.name || 'Guest User'
+    );
+    setMessageText('');
+  };
+
   return (
-    <View style={styles.container}>
-      <View style={styles.logoContainer}>
-        <Image source={require('../../assets/images/logo-white.png')} style={styles.logo} />
+    <>
+      <View style={styles.container}>
+        {messages.map(({ id, text, from, sentAt }) => {
+          return (
+            <Text key={id}>
+              {text}, from: {from}
+            </Text>
+          );
+        })}
+        {!roomId && (
+          <Text>Have any questions or concerns? Send us a message.</Text>
+        )}
+        <TextInput value={messageText} onChangeText={setMessageText} />
+        <TouchableOpacity onPress={sendMessage}>
+          <Text>send</Text>
+        </TouchableOpacity>
       </View>
+      <View style={[styles.container, { display: "none" }]}>
+        <View style={styles.logoContainer}>
+          <Image
+            source={require("../../assets/images/logo-white.png")}
+            style={styles.logo}
+          />
+        </View>
 
-      <Text style={TextStyles.heading1}>{i18nCtx.t('liveChat')}</Text>
-      <Text style={TextStyles.heading2}>{i18nCtx.t('untilThen')}</Text>
+        <Text style={TextStyles.heading1}>{i18nCtx.t("liveChat")}</Text>
+        <Text style={TextStyles.heading2}>{i18nCtx.t("untilThen")}</Text>
 
-      {/*Use empty <Text/>s to add double vertical space where necessary*/}
-      <Text/>
+        {/*Use empty <Text/>s to add double vertical space where necessary*/}
+        <Text />
 
-      <Text style={TextStyles.heading1}>{i18nCtx.t('letsTalk')}</Text>
+        <Text style={TextStyles.heading1}>{i18nCtx.t("letsTalk")}</Text>
 
-      <Text/>
+        <Text />
 
-      <Text style={TextStyles.heading2}>
-        {i18nCtx.t('tel')}: <Text style={[styles.body, styles.link]} onPress={() => Linking.openURL('tel:+18582749673')}>+1 858.274.9673</Text>
-      </Text>
-      <Text style={TextStyles.heading2}>
-        {i18nCtx.t('days')}: <Text style={styles.body}>{i18nCtx.t('hours')}</Text>
-      </Text>
+        <Text style={TextStyles.heading2}>
+          {i18nCtx.t("tel")}:{" "}
+          <Text
+            style={[styles.body, styles.link]}
+            onPress={() => Linking.openURL("tel:+18582749673")}
+          >
+            +1 858.274.9673
+          </Text>
+        </Text>
+        <Text style={TextStyles.heading2}>
+          {i18nCtx.t("days")}:{" "}
+          <Text style={styles.body}>{i18nCtx.t("hours")}</Text>
+        </Text>
 
-      <Text/>
+        <Text />
 
-      <Text style={TextStyles.heading2}>
-        {i18nCtx.t('emailUs')}: <Text style={[styles.body, styles.link]} onPress={() => Linking.openURL('mailto:info@wordsalive.org')}>info@wordsalive.org</Text>
-      </Text>
+        <Text style={TextStyles.heading2}>
+          {i18nCtx.t("emailUs")}:{" "}
+          <Text
+            style={[styles.body, styles.link]}
+            onPress={() => Linking.openURL("mailto:info@wordsalive.org")}
+          >
+            info@wordsalive.org
+          </Text>
+        </Text>
 
-      <Text/>
+        <Text />
 
-      <Text style={TextStyles.heading2}>
-        {i18nCtx.t('address')}:
-      </Text>
+        <Text style={TextStyles.heading2}>{i18nCtx.t("address")}:</Text>
 
-      {/*We would use separate <Text> tags instead of \n's here, but we want the entire address to be selectable as one element so it can be copied or opened in Maps*/}
-      <Text style={styles.body} selectable={true}>5111 Santa Fe Street Suite 219{'\n'}San Diego, California, 92109{'\n'}United States</Text>
-    </View>
+        {/*We would use separate <Text> tags instead of \n's here, but we want the entire address to be selectable as one element so it can be copied or opened in Maps*/}
+        <Text style={styles.body} selectable={true}>
+          5111 Santa Fe Street Suite 219{"\n"}San Diego, California, 92109{"\n"}
+          United States
+        </Text>
+      </View>
+    </>
   );
 };
 

--- a/mobile/src/screens/ChatScreen.tsx
+++ b/mobile/src/screens/ChatScreen.tsx
@@ -84,6 +84,10 @@ export const ChatScreen: React.FC = () => {
     setMessageText('');
   };
 
+  const rateChat = (): void => {
+    chatAPI.rateChat(roomId, 4);
+  };
+
   return (
     <>
       <View style={styles.container}>
@@ -98,7 +102,9 @@ export const ChatScreen: React.FC = () => {
           <Text>Have any questions or concerns? Send us a message.</Text>
         )}
         {chatRoomData && chatRoomData.resolved && !chatRoomData.rating && (
-          <Text>Leave a rating.</Text>
+          <TouchableOpacity onPress={rateChat}>
+            <Text>Leave a rating.</Text>
+          </TouchableOpacity>
         )}
         <TextInput value={messageText} onChangeText={setMessageText} />
         <TouchableOpacity onPress={sendMessage}>

--- a/mobile/src/screens/ChatScreen.tsx
+++ b/mobile/src/screens/ChatScreen.tsx
@@ -39,10 +39,7 @@ export const ChatScreen: React.FC = () => {
 
   // Use roomId from previous session if exist
   useEffect(() => {
-    AsyncStorage.getItem('chatRoomId').then((id) => {
-      console.log('returrietd', id);
-      setRoomId(id);
-    });
+    AsyncStorage.getItem('chatRoomId').then((id) => setRoomId(id));
   }, []);
 
   // Subscribe to chat room data changes
@@ -71,7 +68,7 @@ export const ChatScreen: React.FC = () => {
   const sendMessage = async (): Promise<void> => {
     let newRoomId: string;
     if (!roomId) {
-      // Create a new room
+      // Create a new room if no previous roomId
       newRoomId = await chatAPI.createRoom(auth.user);
       setRoomId(newRoomId);
       AsyncStorage.setItem('chatRoomId', newRoomId);

--- a/mobile/src/screens/ChatScreen.tsx
+++ b/mobile/src/screens/ChatScreen.tsx
@@ -72,14 +72,14 @@ export const ChatScreen: React.FC = () => {
     let newRoomId: string;
     if (!roomId) {
       // Create a new room
-      newRoomId = await chatAPI.createRoom(auth.user?.name || 'Guest User');
+      newRoomId = await chatAPI.createRoom(auth.user);
       setRoomId(newRoomId);
       AsyncStorage.setItem('chatRoomId', newRoomId);
     }
     chatAPI.sendMessage(
       roomId || newRoomId,
       messageText,
-      auth.user?.name || 'Guest User'
+      auth.user?.name
     );
     setMessageText('');
   };

--- a/web/src/api/ChatAPI.ts
+++ b/web/src/api/ChatAPI.ts
@@ -1,0 +1,59 @@
+import firebase from 'firebase/app';
+import 'firebase/firestore';
+import { ChatRoom, Message } from '../models/Chat';
+
+// Class to encapsulate Chat functionality for admins
+class ChatAPI {
+  chatRoomsCollection: firebase.firestore.DocumentData;
+
+  constructor() {
+    const fbConfig = process.env.REACT_APP_FB_CONFIG ? JSON.parse(process.env.REACT_APP_FB_CONFIG) : {
+      apiKey: process.env.REACT_APP_FB_API_KEY || 'AIzaSyBSJHJ-VfdN2Y3wC_vfD1k6bEU2mQmP-Vg',
+      authDomain: process.env.REACT_APP_FB_AUTH_DOMAIN || 'words-alive-staging.firebaseapp.com',
+      projectId: process.env.REACT_APP_FB_PROJECT_ID || 'words-alive-staging',
+      appId: process.env.REACT_APP_FB_APP_ID || '1:1534285739:web:2bada99614d9126d7224ee',
+    };
+    const app = firebase.apps[0] || firebase.initializeApp(fbConfig);
+    const db = app.firestore();
+    this.chatRoomsCollection = db.collection('chatRooms');
+  }
+
+  listenForNewRooms(callback: (rooms: ChatRoom[]) => void): void {
+    this.chatRoomsCollection
+      .orderBy("createdAt", "desc")
+      .onSnapshot((querySnapshot: firebase.firestore.QuerySnapshot) => {
+        const rooms: ChatRoom[] = [];
+        querySnapshot.forEach((doc: firebase.firestore.DocumentData) => {
+          rooms.push({ id: doc.id, ...doc.data() });
+        });
+        callback(rooms);
+      });
+  }
+
+  // Listen for new messages in a chat room (calling this will initially return the current messages)
+  listenForNewMessages(roomId: string, callback: (messages: Message[]) => void): () => void {
+    const room = this.chatRoomsCollection.doc(roomId);
+    const unsubscribe = room
+      .collection("messages")
+      .orderBy("sentAt")
+      .onSnapshot((querySnapshot: firebase.firestore.QuerySnapshot) => {
+        const messages: Message[] = [];
+        querySnapshot.forEach((doc: firebase.firestore.DocumentData) => {
+          messages.push({ id: doc.id, ...doc.data() });
+        });
+        callback(messages);
+      });
+    return unsubscribe;
+  }
+
+  sendMessage(roomId: string, text: string, from: string): void {
+    const room = this.chatRoomsCollection.doc(roomId);
+    room.collection("messages").add({
+      text,
+      from,
+      sentAt: new Date().toUTCString(),
+    });
+  }
+}
+
+export { ChatAPI };

--- a/web/src/api/ChatAPI.ts
+++ b/web/src/api/ChatAPI.ts
@@ -56,6 +56,13 @@ class ChatAPI {
       sentAt: new Date().toUTCString(),
     });
   }
+
+  resolveChat(roomId: string): void {
+    const room = this.chatRoomsCollection.doc(roomId);
+    room.update({
+      resolved: true
+    });
+  }
 }
 
 export { ChatAPI };

--- a/web/src/api/ChatAPI.ts
+++ b/web/src/api/ChatAPI.ts
@@ -20,7 +20,7 @@ class ChatAPI {
 
   listenForNewRooms(callback: (newRooms: ChatRoom[]) => void): () => void {
     const unsubscribe = this.chatRoomsCollection
-      .orderBy("createdAt", "desc")
+      .orderBy('createdAt', 'desc')
       .onSnapshot((querySnapshot: firebase.firestore.QuerySnapshot) => {
         const rooms: ChatRoom[] = [];
         querySnapshot.docChanges().forEach(({type, doc}: firebase.firestore.DocumentChange) => {
@@ -50,7 +50,7 @@ class ChatAPI {
 
   sendMessage(roomId: string, text: string, from: string): void {
     const room = this.chatRoomsCollection.doc(roomId);
-    room.collection("messages").add({
+    room.collection('messages').add({
       text,
       from,
       sentAt: new Date().toUTCString(),

--- a/web/src/components/AdminCard.tsx
+++ b/web/src/components/AdminCard.tsx
@@ -52,6 +52,7 @@ export const AdminCard: React.FC<AdminCardProps> = ({ admin, deleteMode, fetchAd
   const [uploadBooks, setUploadBooks] = useState(false);
   const [editBooks, setEditBooks] = useState(false);
   const [deleteBooks, setDeleteBooks] = useState(false);
+  const [canChat, setCanChat] = useState(false);
 
 
   // upload books toggle
@@ -61,7 +62,7 @@ export const AdminCard: React.FC<AdminCardProps> = ({ admin, deleteMode, fetchAd
     setDeleteBooks(false);
   };
 
-  // diplay the modal for managing and set the current permissions for the admin
+  // display the modal for managing and set the current permissions for the admin
   const displayManageModal = (id: string): void => {
     setManageId(id);
     setManageModal(true);
@@ -70,6 +71,7 @@ export const AdminCard: React.FC<AdminCardProps> = ({ admin, deleteMode, fetchAd
     setUploadBooks(admin.can_upload_books);
     setDeleteBooks(admin.can_delete_books);
     setEditBooks(admin.can_edit_books);
+    setCanChat(admin.can_chat);
   };
 
   // update an admin with call to backend
@@ -83,6 +85,7 @@ export const AdminCard: React.FC<AdminCardProps> = ({ admin, deleteMode, fetchAd
       can_upload_books: uploadBooks,
       can_edit_books: editBooks,
       can_delete_books: deleteBooks,
+      can_chat: canChat
     };
 
     try {
@@ -152,6 +155,7 @@ export const AdminCard: React.FC<AdminCardProps> = ({ admin, deleteMode, fetchAd
                   <div className={styles.allCheckboxesContainer}>
 
                     <Checkbox className={styles.checkbox} label="Manage" id="manageBox" onChange={() => setManageAdmins(prevManage => !prevManage)} checked={manageAdmins} />
+                    <Checkbox className={styles.checkbox} label="Chat" id="chatBox" onChange={() => setCanChat(prevChat => !prevChat)} checked={canChat} />
                     <Checkbox className={styles.checkbox} label="Upload Books" id="uploadBooksBox" onChange={handleUploadToggle} checked={uploadBooks} />
 
                     {uploadBooks ? (

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -20,10 +20,10 @@ export const Navbar: React.FC = () => {
         <li className={styles.nav_element_left}>
           <img className={styles.nav_logo} src="./img/logo.png" alt="Logo" />
         </li>
-        {/* Chat and Analytics tabs - uncomment when ready */}
-        {/*<li className={styles.nav_element_left}>*/}
-        {/*  <NavLink className={styles.nav_link} activeClassName={styles.active} to="/communication">Communication</NavLink>*/}
-        {/*</li>*/}
+        <li className={styles.nav_element_left}>
+          <NavLink className={styles.nav_link} activeClassName={styles.active} to="/communication">Communication</NavLink>
+        </li>
+        {/* Analytics tabs - uncomment when ready */}
         {/*<li className={styles.nav_element_left}>*/}
         {/*  <NavLink className={styles.nav_link} activeClassName={styles.active} to="/analytics">Analytics</NavLink>*/}
         {/*</li>*/}

--- a/web/src/models/Admin.ts
+++ b/web/src/models/Admin.ts
@@ -6,6 +6,7 @@ export type Admin = {
   can_upload_books: boolean
   can_delete_books: boolean
   can_edit_books: boolean
+  can_chat: boolean
   is_primary_admin: boolean
 };
 
@@ -17,6 +18,7 @@ export type CreateAdmin = {
   can_upload_books: boolean
   can_delete_books: boolean
   can_edit_books: boolean
+  can_chat: boolean
 };
 
 export type UpdateAdmin = {
@@ -25,4 +27,5 @@ export type UpdateAdmin = {
   can_upload_books: boolean
   can_delete_books: boolean
   can_edit_books: boolean
+  can_chat: boolean
 };

--- a/web/src/models/Chat.ts
+++ b/web/src/models/Chat.ts
@@ -1,0 +1,15 @@
+export type ChatRoom = {
+  id: string;
+  resolved: boolean;
+  messages: Message[];
+  user: string;
+  rating: number;
+  createdAt: Date;
+};
+
+export type Message = {
+  id: string;
+  text: string;
+  from: string;
+  sentAt: Date;
+};

--- a/web/src/pages/CommunicationPage.tsx
+++ b/web/src/pages/CommunicationPage.tsx
@@ -19,6 +19,7 @@ const Chat: React.FC<ChatProps> = ({ roomId }) => {
   };
 
   useEffect(() => {
+    setMessages([]);
     return chatAPI.listenForNewMessages(roomId, onMessagesChange);
   }, [roomId]);
 
@@ -27,9 +28,13 @@ const Chat: React.FC<ChatProps> = ({ roomId }) => {
     setMessageText("");
   };
 
+  const resolveChat = (): void => {
+    chatAPI.resolveChat(roomId);
+  };
+
   return (
     <div>
-      {messages.map(({ id, text, from, sentAt }) => {
+      {messages.map(({ id, text, from }) => {
         return (
           <p key={id}>
             {text}, from: {from}
@@ -42,6 +47,7 @@ const Chat: React.FC<ChatProps> = ({ roomId }) => {
         onChange={(event) => setMessageText(event.target.value)}
       />
       <button onClick={sendMessage}>send</button>
+      <button onClick={resolveChat}>resolve</button>
     </div>
   );
 };

--- a/web/src/pages/CommunicationPage.tsx
+++ b/web/src/pages/CommunicationPage.tsx
@@ -14,12 +14,12 @@ const Chat: React.FC<ChatProps> = ({ roomId }) => {
   const [messageText, setMessageText] = useState<string>("");
   const auth = useContext(AuthContext);
 
+  const onMessagesChange = (changedMessages: Message[]): void => {
+    setMessages((oldMessages) => [...oldMessages, ...changedMessages]);
+  };
+
   useEffect(() => {
-    const onMessagesChange = (messages: Message[]): void => {
-      setMessages(messages);
-    };
-    const unsubscribe = chatAPI.listenForNewMessages(roomId, onMessagesChange);
-    return unsubscribe;
+    return chatAPI.listenForNewMessages(roomId, onMessagesChange);
   }, [roomId]);
 
   const sendMessage = (): void => {
@@ -50,16 +50,16 @@ export const CommunicationPage: React.FC = () => {
   const [currentRoomId, setCurrentRoomId] = useState<string | undefined>();
   const [chatRooms, setChatRooms] = useState<ChatRoom[]>([]);
 
-  const onRoomsChange = (rooms: ChatRoom[]): void => {
-    setChatRooms(rooms);
-    console.log(currentRoomId);
-    if (currentRoomId === undefined) {
-      setCurrentRoomId(rooms[0].id);
-    }
+  const onNewRooms = (newRooms: ChatRoom[]): void => {
+    setChatRooms(oldRooms => [...oldRooms, ...newRooms]);
   };
 
+  useEffect(()=>{
+    if (!currentRoomId && chatRooms.length > 0) setCurrentRoomId(chatRooms[0].id);
+  }, [chatRooms]);
+
   useEffect(() => {
-    chatAPI.listenForNewRooms(onRoomsChange);
+    return chatAPI.listenForNewRooms(onNewRooms);
   }, []);
 
   if (currentRoomId)

--- a/web/src/pages/CommunicationPage.tsx
+++ b/web/src/pages/CommunicationPage.tsx
@@ -18,6 +18,7 @@ const Chat: React.FC<ChatProps> = ({ roomId }) => {
     setMessages((oldMessages) => [...oldMessages, ...changedMessages]);
   };
 
+  // Listen for new messages in currently selected chat room
   useEffect(() => {
     setMessages([]);
     return chatAPI.listenForNewMessages(roomId, onMessagesChange);
@@ -60,10 +61,12 @@ export const CommunicationPage: React.FC = () => {
     setChatRooms(oldRooms => [...newRooms,...oldRooms]);
   };
 
+  // Automatically select first chat room if none is selected
   useEffect(()=>{
     if (!currentRoomId && chatRooms.length > 0) setCurrentRoomId(chatRooms[0].id);
   }, [chatRooms]);
 
+  // Listen for newly created chat rooms in real time
   useEffect(() => {
     return chatAPI.listenForNewRooms(onNewRooms);
   }, []);

--- a/web/src/pages/CommunicationPage.tsx
+++ b/web/src/pages/CommunicationPage.tsx
@@ -57,7 +57,7 @@ export const CommunicationPage: React.FC = () => {
   const [chatRooms, setChatRooms] = useState<ChatRoom[]>([]);
 
   const onNewRooms = (newRooms: ChatRoom[]): void => {
-    setChatRooms(oldRooms => [...oldRooms, ...newRooms]);
+    setChatRooms(oldRooms => [...newRooms,...oldRooms]);
   };
 
   useEffect(()=>{

--- a/web/src/pages/CommunicationPage.tsx
+++ b/web/src/pages/CommunicationPage.tsx
@@ -1,9 +1,81 @@
-import React from 'react';
+import React, { useContext, useEffect, useState } from "react";
+import { ChatAPI } from "../api/ChatAPI";
+import { AuthContext } from "../context/AuthContext";
+import { ChatRoom, Message } from "../models/Chat";
 
-export const CommunicationPage: React.FC = () => {
+interface ChatProps {
+  roomId: string;
+}
+
+const chatAPI = new ChatAPI();
+
+const Chat: React.FC<ChatProps> = ({ roomId }) => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [messageText, setMessageText] = useState<string>("");
+  const auth = useContext(AuthContext);
+
+  useEffect(() => {
+    const onMessagesChange = (messages: Message[]): void => {
+      setMessages(messages);
+    };
+    const unsubscribe = chatAPI.listenForNewMessages(roomId, onMessagesChange);
+    return unsubscribe;
+  }, [roomId]);
+
+  const sendMessage = (): void => {
+    chatAPI.sendMessage(roomId, messageText, auth.admin?.name || '');
+    setMessageText("");
+  };
+
   return (
     <div>
-      <h1>Communication</h1>
+      {messages.map(({ id, text, from, sentAt }) => {
+        return (
+          <p key={id}>
+            {text}, from: {from}
+          </p>
+        );
+      })}
+      <input
+        type="text"
+        value={messageText}
+        onChange={(event) => setMessageText(event.target.value)}
+      />
+      <button onClick={sendMessage}>send</button>
     </div>
   );
+};
+
+export const CommunicationPage: React.FC = () => {
+  const [currentRoomId, setCurrentRoomId] = useState<string | undefined>();
+  const [chatRooms, setChatRooms] = useState<ChatRoom[]>([]);
+
+  const onRoomsChange = (rooms: ChatRoom[]): void => {
+    setChatRooms(rooms);
+    console.log(currentRoomId);
+    if (currentRoomId === undefined) {
+      setCurrentRoomId(rooms[0].id);
+    }
+  };
+
+  useEffect(() => {
+    chatAPI.listenForNewRooms(onRoomsChange);
+  }, []);
+
+  if (currentRoomId)
+    return (
+      <div>
+        <h1>Communication</h1>
+        {chatRooms.map(({ id, user }: ChatRoom) => {
+          return (
+            <p key={id} onClick={() => setCurrentRoomId(id)}>
+              {user}
+            </p>
+          );
+        })}
+        <h2>chat</h2>
+        <Chat roomId={currentRoomId} />
+      </div>
+    );
+  return <div></div>;
 };

--- a/web/src/pages/ManageAccountsPage.tsx
+++ b/web/src/pages/ManageAccountsPage.tsx
@@ -53,6 +53,7 @@ export const ManageAccountsPage: React.FC = () => {
   const [uploadBooks, setUploadBooks] = useState(false);
   const [editBooks, setEditBooks] = useState(false);
   const [deleteBooks, setDeleteBooks] = useState(false);
+  const [canChat, setCanChat] = useState(false);
 
   // new admin with call to backend
   const handleNewAccount = async (): Promise<void> => {
@@ -74,6 +75,7 @@ export const ManageAccountsPage: React.FC = () => {
         can_upload_books: uploadBooks,
         can_edit_books: editBooks,
         can_delete_books: deleteBooks,
+        can_chat: canChat
       };
 
       try {
@@ -99,6 +101,7 @@ export const ManageAccountsPage: React.FC = () => {
     setUploadBooks(false);
     setEditBooks(false);
     setDeleteBooks(false);
+    setCanChat(false);
   };
 
   // upload books toggle
@@ -175,6 +178,7 @@ export const ManageAccountsPage: React.FC = () => {
                     <div className={styles.allCheckboxesContainer}>
 
                       <Checkbox className={styles.checkbox} label="Manage" id="manageBox" onChange={() => setManageAdmins(prevManage => !prevManage)} checked={manageAdmins} />
+                      <Checkbox className={styles.checkbox} label="Chat" id="chatBox" onChange={() => setCanChat(prevChat => !prevChat)} checked={canChat} />
                       <Checkbox className={styles.checkbox} label="Upload Books" id="uploadBooksBox" onChange={handleUploadToggle} checked={uploadBooks} />
 
                       {uploadBooks ? (


### PR DESCRIPTION
### Administrative Info
Monday Board ID: 853642866
Make sure your branch name conforms to: `<feature/staging/hotfix/...>/[username]/[Monday Item ID]-[3-4 word description separated by dashes]`. Otherwise, please rename your branch and create a new PR.

### Changes
- Build chat API functionality using Firestore (live chat, rating/resolving a chat)
- Update the backend to save `canChat` custom claim to the Firebase Authentication user when an admin is created and updated (if an admins chat permission is updated, they must sign out and sign in again to refresh their token for the change to take effect)
- Update Firebase staging environment with new security rules to manage access to documents

#### Firestore Schemas

**ChatRoom**

```js
{
    createdAt: string, 
    rating: number, // user rating of chat
    resolved: boolean,
    user: string, // name of user who initiated the chat (for displaying on frontend, saves a read operation)
    userId: string // id of user who initiated the chat (used by the Firestore security rules for access control) 
    messages: Subcollection<Message> (see below)
}
```

**Message**

```js
{
    from: string, // user who sent the message (used for rendering correct chat bubble for frontend implementation in the future)
    sentAt: string,
    text: string
}
```

### Testing
- built a rough frontend on web and mobile to test functionality
- made sure chat permission was correctly added/removed on admin create/update
- made sure admins with chat permission have access to all chat rooms
- made sure only logged in users could see their own chat rooms (frontend guard not implemented yet for guest users)

### Confirmation of Change 
![image](https://user-images.githubusercontent.com/24444266/141213283-4029946e-1d81-4247-8cd0-4216f4a231d9.png)

